### PR TITLE
security: remove hardcoded credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+DB_URL=jdbc:oracle:thin:@HOST:PORT:SID
+DB_USERNAME=your_db_username
+DB_PASSWORD=your_db_password
+MAIL_USERNAME=your_gmail_address
+MAIL_APP_PASSWORD=your_gmail_app_password
+GOOGLE_CLIENT_ID=your_google_oauth_client_id
+GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ out/
 
 ### log ###
 /logs/**
+
+### Local secrets / environment ###
+.env
+.env.*
+!.env.example
+application-local.yml
+src/main/resources/application-local.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,9 +21,9 @@ spring:
 
   datasource:
     driver-class-name: oracle.jdbc.driver.OracleDriver
-    url: jdbc:oracle:thin:@3.35.197.89:1522:xe
-    username: team3
-    password: rmflszjavbxj123!
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
     hikari:
       pool-name: HikariPool-GreenGarden   # ✅ 커넥션 풀 이름
@@ -58,8 +58,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: whdqhd4149@gmail.com
-    password: oamopnpsvbpzxfqq
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_APP_PASSWORD}
     properties:
       mail:
         smtp:
@@ -79,7 +79,7 @@ spring:
       client:
         registration:
           google:
-            client-id: 169178720707-ue74ijmhnr3bpaj09uo1pf46ni5v1dgg.apps.googleusercontent.com
-            client-secret: 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
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: [ openid, email, profile ]
             redirect-uri: "{baseUrl}/login/oauth2/code/google"


### PR DESCRIPTION
Removes hardcoded database, Gmail, and Google OAuth credentials from application.yml and replaces them with environment-variable placeholders. Also ignores local secret files and adds a safe .env.example template.

Important: credentials previously committed to Git history must still be rotated/revoked. This PR prevents future plaintext commits but does not erase old commits.